### PR TITLE
backwards compat for nbt separator

### DIFF
--- a/src/main/java/com/fantasticsource/fantasticlib/config/FantasticConfig.java
+++ b/src/main/java/com/fantasticsource/fantasticlib/config/FantasticConfig.java
@@ -55,6 +55,14 @@ public class FantasticConfig
             })
     public static double tooltipScaling = 1;
 
+    @Config.Name("NBT Separator")
+    @Config.LangKey(MODID + ".config.nbtSeparator")
+    @Config.Comment(
+            {
+                    "Matching boxed NBT will use this separator to access keys inside a compound. Before 1.12.2.069 this was \".\""
+            })
+    public static String nbtSeparator = "/";
+
     @Config.Name("GUI Settings")
     @Config.LangKey(MODID + ".config.guiSettings")
     public static GUIConfig guiSettings = new GUIConfig();

--- a/src/main/java/com/fantasticsource/fantasticlib/config/FantasticConfig.java
+++ b/src/main/java/com/fantasticsource/fantasticlib/config/FantasticConfig.java
@@ -59,7 +59,7 @@ public class FantasticConfig
     @Config.LangKey(MODID + ".config.nbtSeparator")
     @Config.Comment(
             {
-                    "Matching boxed NBT will use this separator to access keys inside a compound. Before 1.12.2.069 this was \".\""
+                    "Matching boxed NBT will use this separator to access keys inside a compound. Before 1.12.2.069 this was \":\""
             })
     public static String nbtSeparator = "/";
 

--- a/src/main/java/com/fantasticsource/mctools/items/AdvancedItemFilter.java
+++ b/src/main/java/com/fantasticsource/mctools/items/AdvancedItemFilter.java
@@ -1,6 +1,7 @@
 package com.fantasticsource.mctools.items;
 
 import com.fantasticsource.fantasticlib.FantasticLib;
+import com.fantasticsource.fantasticlib.config.FantasticConfig;
 import com.fantasticsource.tools.Tools;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.Item;
@@ -322,7 +323,7 @@ public class AdvancedItemFilter
         {
             for (Map.Entry<String, String> entry : tagsDisallowed.entrySet())
             {
-                if (checkNBT(compound, entry.getKey().split("/", -1), entry.getValue())) return false;
+                if (checkNBT(compound, entry.getKey().split(FantasticConfig.nbtSeparator, -1), entry.getValue())) return false;
             }
         }
 
@@ -335,7 +336,7 @@ public class AdvancedItemFilter
 
             for (Map.Entry<String, String> entry : tagsRequired.entrySet())
             {
-                if (!checkNBT(compound, entry.getKey().split("/", -1), entry.getValue())) return false;
+                if (!checkNBT(compound, entry.getKey().split(FantasticConfig.nbtSeparator, -1), entry.getValue())) return false;
             }
         }
 

--- a/src/main/resources/assets/fantasticlib/lang/en_us.lang
+++ b/src/main/resources/assets/fantasticlib/lang/en_us.lang
@@ -44,6 +44,8 @@ fantasticlib.config.negativeAttributes=Negative Attributes
 fantasticlib.config.negativeAttributes.tooltip=FILLSCREEN A list of attributes which are bad to have, for render color purposes\n \n
 fantasticlib.config.tooltipScaling=Tooltip Scaling
 fantasticlib.config.tooltipScaling.tooltip=FILLSCREEN Multiplies tooltip render size by this amount\n \n
+fantasticlib.config.nbtSeparator=NBT Separator
+fantasticlib.config.nbtSeparator.tooltip=FILLSCREEN Matching boxed NBT will use this separator to access keys inside a compound. Before 1.12.2.069 this was "."\n \n
 fantasticlib.config.guiSettings=GUI Settings
 fantasticlib.config.raytraceSettings=Raytrace Settings
 


### PR DESCRIPTION
shivaxi was complaining 🌚
fully correct would prob be using quotes to separate nbt key names from accessing boxed nbt but well this has to be enough